### PR TITLE
Add password-protected room entry and roster updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,22 @@
   <style>
     body { font-family: sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
     header { background: #2196f3; color: white; padding: 1rem; text-align: center; }
+    main { display: flex; flex-direction: column; min-height: calc(100vh - 64px); }
+    main.hidden { display: none; }
     #profile { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem 1rem; background: #fff; border-bottom: 1px solid #e0e0e0; }
     #profile label { font-size: 0.9rem; display: flex; flex-direction: column; gap: 0.25rem; }
     #profile input[type=file] { max-width: 200px; }
     #iconPreview { width: 48px; height: 48px; border-radius: 50%; object-fit: cover; background: #ddd; }
     #profile .location-info { margin-left: auto; }
-    #chat { padding: 1rem; height: 50vh; overflow-y: auto; background: white; }
+    #chatLayout { display: flex; flex: 1; gap: 1rem; padding: 1rem; box-sizing: border-box; }
+    #chatPanel { flex: 1; display: flex; flex-direction: column; gap: 1rem; }
+    #roomUsers { width: 220px; background: #fff; border-radius: 0.75rem; padding: 1rem; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08); display: flex; flex-direction: column; gap: 0.5rem; }
+    #roomUsers h2 { margin: 0; font-size: 1rem; color: #333; }
+    #roomUserList { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+    #roomUserList li { background: #fff6e8; border-radius: 999px; padding: 0.5rem 0.75rem; font-size: 0.9rem; color: #5d4037; }
+    #roomUserList li.empty { text-align: center; color: #777; font-style: italic; background: #f5f5f5; }
+    #roomUserList li.self { font-weight: bold; background: #e8f5e9; color: #1b5e20; }
+    #chat { padding: 1rem; flex: 1; overflow-y: auto; background: white; border-radius: 0.75rem; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08); }
     #messages { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.75rem; }
     #messages li { display: flex; gap: 0.75rem; border-bottom: 1px solid #eee; padding-bottom: 0.75rem; }
     #messages li:last-child { border-bottom: none; padding-bottom: 0; }
@@ -27,7 +37,7 @@
     #messages li.system { justify-content: center; text-align: center; color: #666; font-style: italic; }
     #messages li.system .avatar { display: none; }
     #messages li.system .content { flex: 0 1 auto; }
-    #controls { display: flex; gap: 0.5rem; padding: 1rem; background: #fafafa; flex-wrap: wrap; }
+    #controls { display: flex; gap: 0.5rem; padding: 1rem; background: #fafafa; flex-wrap: wrap; border-radius: 0.75rem; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08); }
     #controls input[type=text] { flex: 1 1 200px; padding: 0.5rem; }
     #controls button { padding: 0.5rem 1rem; }
     #callControls { padding: 1rem; text-align: center; display: flex; flex-direction: column; gap: 1rem; }
@@ -40,41 +50,83 @@
     #participantList img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; background: #c5cae9; }
     #participantList span.self { font-weight: bold; }
     #audioElements { display: none; }
+    #joinModal { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.55); display: flex; align-items: center; justify-content: center; padding: 1rem; z-index: 999; }
+    #joinModal.hidden { display: none; }
+    #joinModal .modal-content { background: #fff; border-radius: 0.75rem; padding: 2rem; width: min(360px, 100%); box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2); display: flex; flex-direction: column; gap: 1rem; }
+    #joinModal label { display: flex; flex-direction: column; font-size: 0.95rem; gap: 0.35rem; }
+    #joinModal input { padding: 0.6rem; border-radius: 0.5rem; border: 1px solid #bbb; font-size: 1rem; }
+    #joinModal button { padding: 0.75rem; font-size: 1rem; background: #2196f3; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; }
+    #joinModal button:disabled { background: #90caf9; cursor: not-allowed; }
+    #joinError { color: #d32f2f; min-height: 1.2em; margin: 0; }
+    @media (max-width: 768px) {
+      #chatLayout { flex-direction: column; }
+      #roomUsers { width: 100%; }
+      #chatPanel { width: 100%; }
+    }
   </style>
 </head>
 <body>
   <header>
     <h1>PWA Chat App</h1>
   </header>
-  <section id="profile">
-    <label>
-      アイコンを選択
-      <input id="iconInput" type="file" accept="image/*" />
-    </label>
-    <img id="iconPreview" src="icon-192.png" alt="アイコンのプレビュー" />
-  </section>
+  <main id="appContent" class="hidden">
+    <section id="profile">
+      <label>
+        アイコンを選択
+        <input id="iconInput" type="file" accept="image/*" />
+      </label>
+      <img id="iconPreview" src="icon-192.png" alt="アイコンのプレビュー" />
+    </section>
 
-  <section id="chat">
-    <ul id="messages"></ul>
-  </section>
-  <section id="controls">
-    <input id="input" type="text" placeholder="メッセージを入力…" autocomplete="off" />
-    <button id="send">送信</button>
-    <button id="shareLocation">位置情報を共有</button>
-  </section>
-  <section id="callControls">
-    <div class="buttons">
-      <button id="startCall">通話を開始</button>
-      <button id="endCall" disabled>通話を終了</button>
+    <section id="chatLayout">
+      <aside id="roomUsers">
+        <h2>入室中のユーザー</h2>
+        <ul id="roomUserList">
+          <li class="empty">まだユーザーはいません。</li>
+        </ul>
+      </aside>
+      <div id="chatPanel">
+        <section id="chat">
+          <ul id="messages"></ul>
+        </section>
+        <section id="controls">
+          <input id="input" type="text" placeholder="メッセージを入力…" autocomplete="off" />
+          <button id="send">送信</button>
+          <button id="shareLocation">位置情報を共有</button>
+        </section>
+      </div>
+    </section>
+
+    <section id="callControls">
+      <div class="buttons">
+        <button id="startCall">通話を開始</button>
+        <button id="endCall" disabled>通話を終了</button>
+      </div>
+      <div id="callParticipants">
+        <h2>通話参加者</h2>
+        <ul id="participantList">
+          <li class="empty">現在、通話に参加しているユーザーはいません。</li>
+        </ul>
+      </div>
+      <div id="audioElements" aria-hidden="true"></div>
+    </section>
+  </main>
+
+  <div id="joinModal" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <h2>ルームに参加</h2>
+      <label>
+        ユーザー名
+        <input id="userNameInput" type="text" placeholder="ユーザー名" autocomplete="nickname" />
+      </label>
+      <label>
+        パスワード
+        <input id="passwordInput" type="password" placeholder="パスワード" autocomplete="current-password" />
+      </label>
+      <p id="joinError" aria-live="polite"></p>
+      <button id="joinRoom">ルームに参加</button>
     </div>
-    <div id="callParticipants">
-      <h2>通話参加者</h2>
-      <ul id="participantList">
-        <li class="empty">現在、通話に参加しているユーザーはいません。</li>
-      </ul>
-    </div>
-    <div id="audioElements" aria-hidden="true"></div>
-  </section>
+  </div>
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="app.js"></script>

--- a/server.js
+++ b/server.js
@@ -21,11 +21,14 @@ const io = new Server(server);
 // Serve static assets from the public directory
 app.use(express.static(__dirname));
 // Map of room names to array of socket IDs; used for group chat and voice calls
+const ROOM_PASSWORD = '0623';
 const rooms = new Map();
 // Store basic profile info per socket to show user-friendly names
 const userProfiles = new Map();
 // Track current call participants per room so the UI can display them
 const callParticipants = new Map();
+// Track all room members so the client can display a roster
+const roomMembers = new Map();
 
 function broadcastParticipants(room) {
   const participants = callParticipants.get(room);
@@ -33,52 +36,97 @@ function broadcastParticipants(room) {
   io.to(room).emit('call-participants', payload);
 }
 
+function emitRoomUsers(room) {
+  const members = roomMembers.get(room);
+  const payload = members
+    ? Array.from(members.values()).map(({ id, user }) => ({ id, user }))
+    : [];
+  io.to(room).emit('room-users', payload);
+}
+
 io.on('connection', (socket) => {
   console.log('a user connected:', socket.id);
 
   // Join a room for group chat; default to 'global'
-  socket.on('join', (payload = 'global') => {
+  socket.on('join', (payload = 'global', maybeCallback) => {
+    const callback = typeof maybeCallback === 'function' ? maybeCallback : undefined;
     const isObject = payload && typeof payload === 'object';
     const room = isObject ? payload.room || 'global' : payload || 'global';
-    if (!rooms.has(room)) rooms.set(room, []);
-    const ids = rooms.get(room);
-    if (!ids.includes(socket.id)) {
-      ids.push(socket.id);
+    const password = isObject ? payload.password : undefined;
+    const rawName = isObject && typeof payload.user === 'string' ? payload.user.trim() : '';
+    if (password !== ROOM_PASSWORD) {
+      if (callback) callback({ ok: false, error: 'パスワードが違います。' });
+      return;
     }
+    if (!rawName) {
+      if (callback) callback({ ok: false, error: 'ユーザー名を入力してください。' });
+      return;
+    }
+
+    const icon = isObject && Object.prototype.hasOwnProperty.call(payload, 'icon') && payload.icon
+      ? payload.icon
+      : null;
+
+    let ids = rooms.get(room);
+    if (!ids) {
+      ids = new Set();
+      rooms.set(room, ids);
+    }
+    ids.add(socket.id);
     socket.join(room);
 
-    const existingProfile = userProfiles.get(socket.id) || {};
-    let user = existingProfile.user;
-    if (isObject && typeof payload.user === 'string' && payload.user.trim()) {
-      user = payload.user.trim();
+    const profile = { user: rawName, icon, room };
+    userProfiles.set(socket.id, profile);
+
+    let members = roomMembers.get(room);
+    if (!members) {
+      members = new Map();
+      roomMembers.set(room, members);
     }
-    if (!user) {
-      user = socket.id;
-    }
-    let icon = existingProfile.icon ?? null;
-    if (isObject && Object.prototype.hasOwnProperty.call(payload, 'icon')) {
-      icon = payload.icon || null;
-    }
-    userProfiles.set(socket.id, { user, icon });
+    members.set(socket.id, { id: socket.id, user: rawName, icon });
 
     // Notify others with a friendlier name when available
-    socket.to(room).emit('system', `${user} joined ${room}`);
+    socket.to(room).emit('system', `${rawName} joined ${room}`);
 
     const participants = callParticipants.get(room);
     socket.emit('call-participants', participants ? Array.from(participants.values()) : []);
+    emitRoomUsers(room);
+
+    if (callback) callback({ ok: true });
   });
 
   // Chat message within a room
-  socket.on('message', (msg) => {
-    const { room = 'global', text, user, icon, location } = msg;
+  socket.on('message', (msg = {}) => {
+    const profile = userProfiles.get(socket.id);
+    if (!profile || !profile.room) {
+      return;
+    }
+    const requestedRoom = typeof msg.room === 'string' && msg.room.trim() ? msg.room : profile.room;
+    const ids = rooms.get(requestedRoom);
+    if (!ids || !ids.has(socket.id)) {
+      return;
+    }
+    const text = typeof msg.text === 'string' ? msg.text.trim() : '';
+    const location = msg.location;
+    const incomingIcon = msg.icon;
+    const icon = profile.icon || incomingIcon || null;
+    if (incomingIcon && !profile.icon) {
+      const updatedProfile = { ...profile, icon: incomingIcon };
+      userProfiles.set(socket.id, updatedProfile);
+      const members = roomMembers.get(requestedRoom);
+      if (members && members.has(socket.id)) {
+        const existing = members.get(socket.id);
+        members.set(socket.id, { ...existing, icon: incomingIcon });
+      }
+    }
     const payload = {
-      user,
+      user: profile.user,
       time: Date.now(),
     };
     if (text) payload.text = text;
     if (icon) payload.icon = icon;
     if (location) payload.location = location;
-    io.to(room).emit('message', payload);
+    io.to(requestedRoom).emit('message', payload);
   });
 
   // Signaling messages for WebRTC; forward to all peers in the room
@@ -89,7 +137,9 @@ io.on('connection', (socket) => {
   socket.on('call-participation', (data = {}) => {
     const { action } = data;
     if (!action) return;
-    const room = data.room || 'global';
+    const profile = userProfiles.get(socket.id);
+    if (!profile || !profile.room) return;
+    const room = data.room || profile.room;
     const participants = callParticipants.get(room) || new Map();
     let changed = false;
 
@@ -104,7 +154,7 @@ io.on('connection', (socket) => {
         }
       }
     } else if (action === 'join' || action === 'update') {
-      const existingProfile = userProfiles.get(socket.id) || {};
+      const existingProfile = profile;
       const nameFromData = typeof data.user === 'string' && data.user.trim() ? data.user.trim() : undefined;
       const iconFromData = Object.prototype.hasOwnProperty.call(data, 'icon') ? data.icon || null : undefined;
       const participantUser = nameFromData || existingProfile.user || socket.id;
@@ -112,7 +162,13 @@ io.on('connection', (socket) => {
       const info = { id: socket.id, user: participantUser, icon: participantIcon };
       participants.set(socket.id, info);
       callParticipants.set(room, participants);
-      userProfiles.set(socket.id, { user: participantUser, icon: participantIcon });
+      userProfiles.set(socket.id, { user: participantUser, icon: participantIcon, room });
+      const members = roomMembers.get(room);
+      if (members && members.has(socket.id)) {
+        members.set(socket.id, { id: socket.id, user: participantUser, icon: participantIcon });
+        roomMembers.set(room, members);
+        emitRoomUsers(room);
+      }
       changed = true;
     }
 
@@ -125,24 +181,38 @@ io.on('connection', (socket) => {
   socket.on('disconnect', () => {
     console.log('user disconnected:', socket.id);
     const profile = userProfiles.get(socket.id);
-    for (const [room, ids] of rooms.entries()) {
-      const idx = ids.indexOf(socket.id);
-      if (idx !== -1) {
-        ids.splice(idx, 1);
-        const displayName = profile?.user || socket.id;
-        socket.to(room).emit('system', `${displayName} left ${room}`);
-        const participants = callParticipants.get(room);
-        if (participants && participants.has(socket.id)) {
-          participants.delete(socket.id);
-          if (participants.size === 0) {
-            callParticipants.delete(room);
-          } else {
-            callParticipants.set(room, participants);
-          }
-          broadcastParticipants(room);
+    const room = profile?.room;
+    if (room) {
+      const ids = rooms.get(room);
+      if (ids) {
+        ids.delete(socket.id);
+        if (ids.size === 0) {
+          rooms.delete(room);
+        } else {
+          rooms.set(room, ids);
         }
-        if (ids.length === 0) rooms.delete(room);
-        break;
+      }
+      const displayName = profile?.user || socket.id;
+      socket.to(room).emit('system', `${displayName} left ${room}`);
+      const participants = callParticipants.get(room);
+      if (participants && participants.has(socket.id)) {
+        participants.delete(socket.id);
+        if (participants.size === 0) {
+          callParticipants.delete(room);
+        } else {
+          callParticipants.set(room, participants);
+        }
+        broadcastParticipants(room);
+      }
+      const members = roomMembers.get(room);
+      if (members && members.has(socket.id)) {
+        members.delete(socket.id);
+        if (members.size === 0) {
+          roomMembers.delete(room);
+        } else {
+          roomMembers.set(room, members);
+        }
+        emitRoomUsers(room);
       }
     }
     userProfiles.delete(socket.id);
@@ -150,6 +220,12 @@ io.on('connection', (socket) => {
 });
 
 const PORT = process.env.PORT || 3000;
+
+const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
+setInterval(() => {
+  io.emit('clear-history');
+}, TWELVE_HOURS_MS);
+
 server.listen(PORT, () => {
   console.log(`Server listening on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add a modal join flow that requires entering a username and the shared password before unlocking the chat UI
- show the list of active room members in the client and clear chat history automatically every 12 hours
- enforce the password check and maintain synchronized member rosters on the server

## Testing
- ⚠️ `node server.js` *(fails: missing express dependency because packages cannot be installed in this environment)*
- ⚠️ `npm install` *(fails: registry access forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbd09b598832eb630c3b1e2258569