### PR TITLE
Add multi-room management, offline history, and notifications

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@
 
 (() => {
   const socket = io();
-  const ROOM = 'global';
+  let ROOM = null;
   const messagesEl = document.getElementById('messages');
   const inputEl = document.getElementById('input');
   const sendBtn = document.getElementById('send');
@@ -21,18 +21,41 @@
   const iconPreview = document.getElementById('iconPreview');
   const appContent = document.getElementById('appContent');
   const joinModal = document.getElementById('joinModal');
+  const roomNameInput = document.getElementById('roomNameInput');
+  const roomOptions = document.getElementById('roomOptions');
   const userNameInput = document.getElementById('userNameInput');
   const passwordInput = document.getElementById('passwordInput');
   const joinBtn = document.getElementById('joinRoom');
   const joinError = document.getElementById('joinError');
   const roomUserListEl = document.getElementById('roomUserList');
+  const openAdminBtn = document.getElementById('openAdmin');
+  const adminModal = document.getElementById('adminModal');
+  const adminCloseBtn = document.getElementById('closeAdmin');
+  const adminLoginSection = document.getElementById('adminLoginSection');
+  const adminPanel = document.getElementById('adminPanel');
+  const adminPasswordInput = document.getElementById('adminPasswordInput');
+  const adminLoginBtn = document.getElementById('adminLoginBtn');
+  const adminError = document.getElementById('adminError');
+  const adminRoomList = document.getElementById('adminRoomList');
+  const createRoomForm = document.getElementById('createRoomForm');
+  const newRoomNameInput = document.getElementById('newRoomName');
+  const newRoomPasswordInput = document.getElementById('newRoomPassword');
+  const adminLogoutBtn = document.getElementById('adminLogout');
 
+  const LOCAL_MESSAGES_PREFIX = 'chat-messages:';
+
+  let availableRooms = [];
+  let adminToken = null;
   let userName = '';
+  
   let userIcon = localStorage.getItem('userIcon') || null;
   let joined = false;
   let inCall = false;
   let localAudioEl = null;
   let remoteAudioEl = null;
+  let notificationPermission = typeof Notification !== 'undefined' ? Notification.permission : 'default';
+
+  const LOCAL_MESSAGE_LIMIT = 500;
 
   function setInteractionEnabled(enabled) {
     inputEl.disabled = !enabled;
@@ -52,6 +75,81 @@
   }
 
   setInteractionEnabled(false);
+
+  function getMessagesKey(room) {
+    return `${LOCAL_MESSAGES_PREFIX}${room}`;
+  }
+
+  function loadLocalMessages(room) {
+    if (!room) return [];
+    try {
+      const raw = localStorage.getItem(getMessagesKey(room));
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      console.warn('Failed to load local messages:', error);
+      return [];
+    }
+  }
+
+  function saveLocalMessages(room, messages) {
+    if (!room) return;
+    try {
+      const trimmed = Array.isArray(messages)
+        ? messages.slice(-LOCAL_MESSAGE_LIMIT)
+        : [];
+      localStorage.setItem(getMessagesKey(room), JSON.stringify(trimmed));
+    } catch (error) {
+      console.warn('Failed to save messages:', error);
+    }
+  }
+
+  function appendLocalMessage(room, message) {
+    if (!room || !message) return;
+    const messages = loadLocalMessages(room);
+    messages.push(message);
+    saveLocalMessages(room, messages);
+  }
+
+  function clearLocalMessages(room) {
+    if (!room) return;
+    try {
+      localStorage.removeItem(getMessagesKey(room));
+    } catch (error) {
+      console.warn('Failed to clear local messages:', error);
+    }
+  }
+
+  function mergeMessages(serverMessages = [], localMessages = []) {
+    const combined = [];
+    if (Array.isArray(serverMessages)) {
+      combined.push(...serverMessages);
+    }
+    if (Array.isArray(localMessages)) {
+      combined.push(...localMessages);
+    }
+    const seen = new Set();
+    const unique = [];
+    combined.forEach((msg) => {
+      if (!msg || typeof msg !== 'object') return;
+      const time = typeof msg.time === 'number' ? msg.time : 0;
+      const text = typeof msg.text === 'string' ? msg.text : '';
+      const location = msg.location && typeof msg.location === 'object'
+        ? `${msg.location.latitude ?? ''},${msg.location.longitude ?? ''}`
+        : '';
+      const key = `${msg.user || ''}|${time}|${text}|${location}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      unique.push(msg);
+    });
+    unique.sort((a, b) => {
+      const aTime = typeof a.time === 'number' ? a.time : 0;
+      const bTime = typeof b.time === 'number' ? b.time : 0;
+      return aTime - bTime;
+    });
+    return unique;
+  }
 
   function renderParticipants(participants) {
     participantListEl.innerHTML = '';
@@ -106,7 +204,7 @@
   renderRoomUsers([]);
 
   function updateCallParticipation(action) {
-    if (!joined) return;
+    if (!joined || !ROOM) return;
     socket.emit('call-participation', {
       room: ROOM,
       action,
@@ -143,10 +241,25 @@
     iconPreview.src = userIcon;
   }
 
+  const storedUserName = localStorage.getItem('userName');
+  if (storedUserName) {
+    userNameInput.value = storedUserName;
+  }
+  const storedRoom = localStorage.getItem('lastRoom');
+  if (storedRoom) {
+    roomNameInput.value = storedRoom;
+  }
+
   function attemptJoin() {
     if (joinBtn.disabled) return;
+    const roomName = roomNameInput.value.trim();
     const name = userNameInput.value.trim();
     const password = passwordInput.value.trim();
+    if (!roomName) {
+      joinError.textContent = 'ルーム名を入力してください。';
+      roomNameInput.focus();
+      return;
+    }
     if (!name) {
       joinError.textContent = 'ユーザー名を入力してください。';
       userNameInput.focus();
@@ -160,7 +273,7 @@
 
     joinError.textContent = '';
     joinBtn.disabled = true;
-    socket.emit('join', { room: ROOM, user: name, password, icon: userIcon || null }, (response) => {
+    socket.emit('join', { room: roomName, user: name, password, icon: userIcon || null }, (response) => {
       joinBtn.disabled = false;
       if (!response || response.ok !== true) {
         joinError.textContent = response && response.error ? response.error : 'ルームに参加できませんでした。';
@@ -169,8 +282,16 @@
         return;
       }
 
+      ROOM = response.room || roomName;
       userName = name;
       joined = true;
+      localStorage.setItem('userName', userName);
+      localStorage.setItem('lastRoom', ROOM);
+      const serverMessages = Array.isArray(response.messages) ? response.messages : [];
+      const localMessages = loadLocalMessages(ROOM);
+      const mergedMessages = mergeMessages(serverMessages, localMessages);
+      saveLocalMessages(ROOM, mergedMessages);
+      renderMessages(mergedMessages);
       joinModal.classList.add('hidden');
       appContent.classList.remove('hidden');
       passwordInput.value = '';
@@ -191,12 +312,182 @@
       attemptJoin();
     }
   });
+  roomNameInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      attemptJoin();
+    }
+  });
 
-  userNameInput.focus();
+  if (roomNameInput.value) {
+    if (userNameInput.value) {
+      passwordInput.focus();
+    } else {
+      userNameInput.focus();
+    }
+  } else {
+    roomNameInput.focus();
+  }
 
-  function addMessage({ user, text, time, icon, location }) {
+  fetchRooms();
+  requestNotificationPermission();
+
+  if (openAdminBtn) {
+    openAdminBtn.addEventListener('click', () => {
+      adminError.textContent = '';
+      adminModal.classList.remove('hidden');
+      if (adminToken) {
+        setAdminView(true);
+        loadAdminRooms();
+      } else {
+        setAdminView(false);
+        adminPasswordInput.value = '';
+        adminPasswordInput.focus();
+      }
+    });
+  }
+
+  if (adminCloseBtn) {
+    adminCloseBtn.addEventListener('click', () => {
+      adminModal.classList.add('hidden');
+    });
+  }
+
+  async function handleAdminLogin() {
+    const password = adminPasswordInput.value.trim();
+    if (!password) {
+      adminError.textContent = '管理者パスワードを入力してください。';
+      adminPasswordInput.focus();
+      return;
+    }
+    adminError.textContent = '';
+    adminLoginBtn.disabled = true;
+    try {
+      const response = await fetch('/api/admin/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ password }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.ok) {
+        const message = data && data.error ? data.error : 'ログインに失敗しました。';
+        adminError.textContent = message;
+        adminPasswordInput.focus();
+        adminPasswordInput.select();
+        return;
+      }
+      adminToken = data.token;
+      adminPasswordInput.value = '';
+      setAdminView(true);
+      renderAdminRooms(data.rooms || []);
+      fetchRooms();
+    } catch (error) {
+      console.warn('管理者ログインに失敗しました:', error);
+      adminError.textContent = 'ログインに失敗しました。時間をおいて再度お試しください。';
+    } finally {
+      adminLoginBtn.disabled = false;
+    }
+  }
+
+  if (adminLoginBtn) {
+    adminLoginBtn.addEventListener('click', handleAdminLogin);
+  }
+
+  if (adminPasswordInput) {
+    adminPasswordInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        handleAdminLogin();
+      }
+    });
+  }
+
+  if (createRoomForm) {
+    createRoomForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!adminToken) {
+        adminError.textContent = '管理者としてログインしてください。';
+        return;
+      }
+      const name = newRoomNameInput.value.trim();
+      const password = newRoomPasswordInput.value.trim();
+      if (!name) {
+        adminError.textContent = 'ルーム名を入力してください。';
+        newRoomNameInput.focus();
+        return;
+      }
+      if (!password) {
+        adminError.textContent = 'ルームのパスワードを入力してください。';
+        newRoomPasswordInput.focus();
+        return;
+      }
+      adminError.textContent = '';
+      const submitBtn = createRoomForm.querySelector('button[type="submit"]');
+      if (submitBtn) submitBtn.disabled = true;
+      try {
+        const response = await fetch('/api/admin/rooms', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-admin-token': adminToken,
+          },
+          body: JSON.stringify({ name, password }),
+        });
+        const data = await response.json().catch(() => ({}));
+        if (response.status === 401) {
+          adminToken = null;
+          setAdminView(false);
+          adminError.textContent = '認証の有効期限が切れました。再度ログインしてください。';
+          return;
+        }
+        if (!response.ok || !data.ok) {
+          const message = data && data.error ? data.error : 'ルームの作成に失敗しました。';
+          adminError.textContent = message;
+          return;
+        }
+        newRoomNameInput.value = '';
+        newRoomPasswordInput.value = '';
+        renderAdminRooms(data.rooms || []);
+        fetchRooms();
+      } catch (error) {
+        console.warn('ルームの作成に失敗しました:', error);
+        adminError.textContent = 'ルームの作成に失敗しました。';
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
+      }
+    });
+  }
+
+  if (adminLogoutBtn) {
+    adminLogoutBtn.addEventListener('click', async () => {
+      if (!adminToken) {
+        adminModal.classList.add('hidden');
+        return;
+      }
+      try {
+        await fetch('/api/admin/logout', {
+          method: 'POST',
+          headers: {
+            'x-admin-token': adminToken,
+          },
+        });
+      } catch (error) {
+        console.warn('ログアウト処理に失敗しました:', error);
+      }
+      adminToken = null;
+      setAdminView(false);
+      adminError.textContent = 'ログアウトしました。';
+      adminPasswordInput.value = '';
+      adminPasswordInput.focus();
+    });
+  }
+
+  function addMessage(message, { persist = true } = {}) {
+    if (!message || typeof message !== 'object') return;
+    const { user, text, time, icon, location } = message;
     const li = document.createElement('li');
-    const timestamp = new Date(time).toLocaleTimeString();
+    const timestampValue = typeof time === 'number' ? time : Date.now();
+    const timestamp = new Date(timestampValue).toLocaleTimeString();
     if (user === 'system') {
       li.classList.add('system');
       const content = document.createElement('div');
@@ -243,6 +534,217 @@
     }
     messagesEl.appendChild(li);
     messagesEl.scrollTop = messagesEl.scrollHeight;
+
+    if (persist && ROOM) {
+      appendLocalMessage(ROOM, {
+        user,
+        text,
+        time: timestampValue,
+        icon,
+        location,
+      });
+    }
+  }
+
+  function renderMessages(messages) {
+    messagesEl.innerHTML = '';
+    if (!Array.isArray(messages)) return;
+    messages.forEach((message) => addMessage(message, { persist: false }));
+  }
+
+  function renderRoomOptionsList(rooms) {
+    availableRooms = Array.isArray(rooms) ? rooms : [];
+    roomOptions.innerHTML = '';
+    availableRooms.forEach(({ name }) => {
+      if (!name) return;
+      const option = document.createElement('option');
+      option.value = name;
+      roomOptions.appendChild(option);
+    });
+  }
+
+  async function fetchRooms() {
+    try {
+      const response = await fetch('/api/rooms');
+      if (!response.ok) {
+        throw new Error(`Failed to load rooms: ${response.status}`);
+      }
+      const data = await response.json();
+      if (data && Array.isArray(data.rooms)) {
+        renderRoomOptionsList(data.rooms);
+      }
+    } catch (error) {
+      console.warn('部屋一覧を取得できませんでした:', error);
+    }
+  }
+
+  async function requestNotificationPermission() {
+    if (typeof Notification === 'undefined') {
+      return;
+    }
+    if (notificationPermission === 'default') {
+      try {
+        notificationPermission = await Notification.requestPermission();
+      } catch (error) {
+        console.warn('通知の権限リクエストに失敗しました:', error);
+      }
+    }
+  }
+
+  function showNotification(message) {
+    if (typeof Notification === 'undefined' || notificationPermission !== 'granted') {
+      return;
+    }
+    const title = message.user ? `${message.user}からの新着メッセージ` : '新着メッセージ';
+    let body = '';
+    if (message.text) {
+      body = message.text;
+    } else if (message.location) {
+      body = '位置情報が共有されました。';
+    }
+    const icon = message.icon || 'icon-192.png';
+    try {
+      if (navigator.serviceWorker && navigator.serviceWorker.ready) {
+        navigator.serviceWorker.ready
+          .then((registration) => {
+            if (registration.showNotification) {
+              registration.showNotification(title, {
+                body,
+                icon,
+                data: { room: ROOM },
+              });
+            } else {
+              new Notification(title, { body, icon });
+            }
+          })
+          .catch(() => {
+            new Notification(title, { body, icon });
+          });
+      } else {
+        new Notification(title, { body, icon });
+      }
+    } catch (error) {
+      console.warn('通知の表示に失敗しました:', error);
+    }
+  }
+
+  function setAdminView(loggedIn) {
+    if (loggedIn) {
+      adminLoginSection.classList.add('hidden');
+      adminPanel.classList.remove('hidden');
+    } else {
+      adminPanel.classList.add('hidden');
+      adminLoginSection.classList.remove('hidden');
+    }
+  }
+
+  function renderAdminRooms(rooms) {
+    adminRoomList.innerHTML = '';
+    if (!Array.isArray(rooms) || rooms.length === 0) {
+      const emptyItem = document.createElement('li');
+      emptyItem.className = 'empty';
+      emptyItem.textContent = '登録済みのルームはありません。';
+      adminRoomList.appendChild(emptyItem);
+      return;
+    }
+
+    rooms.forEach(({ name, password, createdAt }) => {
+      if (!name) return;
+      const item = document.createElement('li');
+      item.className = 'admin-room-item';
+
+      const info = document.createElement('div');
+      info.className = 'info';
+      const nameEl = document.createElement('span');
+      nameEl.className = 'name';
+      nameEl.textContent = name;
+      const passwordEl = document.createElement('span');
+      passwordEl.className = 'password';
+      passwordEl.textContent = `パスワード: ${password || '(未設定)'}`;
+      info.appendChild(nameEl);
+      info.appendChild(passwordEl);
+
+      if (createdAt) {
+        const metaEl = document.createElement('span');
+        metaEl.className = 'meta';
+        metaEl.textContent = new Date(createdAt).toLocaleString();
+        info.appendChild(metaEl);
+      }
+
+      const actions = document.createElement('div');
+      actions.className = 'actions';
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'danger';
+      deleteBtn.textContent = '削除';
+      deleteBtn.addEventListener('click', () => {
+        if (!adminToken) return;
+        if (!confirm(`ルーム「${name}」を削除しますか？`)) {
+          return;
+        }
+        deleteAdminRoom(name);
+      });
+      actions.appendChild(deleteBtn);
+
+      item.appendChild(info);
+      item.appendChild(actions);
+      adminRoomList.appendChild(item);
+    });
+  }
+
+  async function loadAdminRooms() {
+    if (!adminToken) return;
+    try {
+      const response = await fetch('/api/admin/rooms', {
+        headers: {
+          'x-admin-token': adminToken,
+        },
+      });
+      if (response.status === 401) {
+        adminToken = null;
+        setAdminView(false);
+        adminError.textContent = '認証の有効期限が切れました。再度ログインしてください。';
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(`Failed to load admin rooms: ${response.status}`);
+      }
+      const data = await response.json();
+      renderAdminRooms(data.rooms || []);
+    } catch (error) {
+      console.warn('管理者用ルーム一覧の取得に失敗しました:', error);
+      adminError.textContent = 'ルーム一覧の取得に失敗しました。';
+    }
+  }
+
+  async function deleteAdminRoom(name) {
+    if (!adminToken) return;
+    adminError.textContent = '';
+    try {
+      const response = await fetch(`/api/admin/rooms/${encodeURIComponent(name)}`, {
+        method: 'DELETE',
+        headers: {
+          'x-admin-token': adminToken,
+        },
+      });
+      if (response.status === 401) {
+        adminToken = null;
+        setAdminView(false);
+        adminError.textContent = '認証の有効期限が切れました。再度ログインしてください。';
+        return;
+      }
+      const data = await response.json();
+      if (!response.ok || !data.ok) {
+        const message = data && data.error ? data.error : 'ルームの削除に失敗しました。';
+        adminError.textContent = message;
+        return;
+      }
+      renderAdminRooms(data.rooms || []);
+      fetchRooms();
+    } catch (error) {
+      console.warn('ルームの削除に失敗しました:', error);
+      adminError.textContent = 'ルームの削除に失敗しました。';
+    }
   }
 
   iconInput.addEventListener('change', (event) => {
@@ -266,7 +768,7 @@
 
   // Send chat message
   sendBtn.addEventListener('click', () => {
-    if (!joined) return;
+    if (!joined || !ROOM) return;
     const text = inputEl.value.trim();
     if (text) {
       socket.emit('message', { user: userName, text, room: ROOM, icon: userIcon });
@@ -283,10 +785,13 @@
   // Receive chat message
   socket.on('message', (msg) => {
     addMessage(msg);
+    if (document.hidden) {
+      showNotification(msg);
+    }
   });
 
   socket.on('system', (msg) => {
-    addMessage({ user: 'system', text: msg, time: Date.now() });
+    addMessage({ user: 'system', text: msg, time: Date.now() }, { persist: false });
   });
 
   socket.on('call-participants', (participants) => {
@@ -297,13 +802,51 @@
     renderRoomUsers(users);
   });
 
-  socket.on('clear-history', () => {
-    messagesEl.innerHTML = '';
-    addMessage({ user: 'system', text: 'チャット履歴はリセットされました。', time: Date.now() });
+  socket.on('clear-history', (payload = {}) => {
+    const targetRoom = payload.room || ROOM;
+    if (!ROOM || targetRoom !== ROOM) {
+      if (payload.room) {
+        clearLocalMessages(payload.room);
+      }
+      return;
+    }
+    clearLocalMessages(ROOM);
+    renderMessages([]);
+    addMessage({ user: 'system', text: 'チャット履歴はリセットされました。', time: Date.now() }, { persist: false });
+  });
+
+  socket.on('rooms-update', (rooms) => {
+    renderRoomOptionsList(rooms);
+    if (adminToken) {
+      loadAdminRooms();
+    }
+  });
+
+  socket.on('room-deleted', ({ room } = {}) => {
+    if (room) {
+      clearLocalMessages(room);
+      if (ROOM === room) {
+        if (inCall) {
+          endCall();
+        }
+        joined = false;
+        ROOM = null;
+        setInteractionEnabled(false);
+        refreshCallButtons();
+        renderMessages([]);
+        renderParticipants([]);
+        renderRoomUsers([]);
+        appContent.classList.add('hidden');
+        joinModal.classList.remove('hidden');
+        joinError.textContent = '参加中のルームは管理者により削除されました。別のルームを選択してください。';
+        roomNameInput.focus();
+      }
+    }
+    fetchRooms();
   });
 
   shareLocationBtn.addEventListener('click', () => {
-    if (!joined) {
+    if (!joined || !ROOM) {
       alert('ルームに参加してから位置情報を共有してください。');
       return;
     }

--- a/index.html
+++ b/index.html
@@ -8,7 +8,12 @@
   <title>PWA Chat App</title>
   <style>
     body { font-family: sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
-    header { background: #2196f3; color: white; padding: 1rem; text-align: center; }
+    header { background: #2196f3; color: white; padding: 1rem; }
+    .header-inner { display: flex; align-items: center; justify-content: space-between; gap: 1rem; max-width: 960px; margin: 0 auto; }
+    header h1 { margin: 0; font-size: 1.75rem; }
+    .admin-button { background: rgba(255, 255, 255, 0.18); color: #fff; border: 1px solid rgba(255, 255, 255, 0.4); border-radius: 999px; padding: 0.5rem 1rem; font-size: 0.95rem; cursor: pointer; transition: background 0.2s ease; }
+    .admin-button:hover { background: rgba(255, 255, 255, 0.3); }
+    .admin-button:focus { outline: 2px solid rgba(255, 255, 255, 0.7); outline-offset: 2px; }
     main { display: flex; flex-direction: column; min-height: calc(100vh - 64px); }
     main.hidden { display: none; }
     #profile { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem 1rem; background: #fff; border-bottom: 1px solid #e0e0e0; }
@@ -58,6 +63,35 @@
     #joinModal button { padding: 0.75rem; font-size: 1rem; background: #2196f3; color: #fff; border: none; border-radius: 0.5rem; cursor: pointer; }
     #joinModal button:disabled { background: #90caf9; cursor: not-allowed; }
     #joinError { color: #d32f2f; min-height: 1.2em; margin: 0; }
+    #adminModal { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.55); display: flex; align-items: center; justify-content: center; padding: 1rem; z-index: 1000; }
+    #adminModal.hidden { display: none; }
+    #adminModal .modal-content { background: #fff; border-radius: 0.75rem; padding: 2rem; width: min(520px, 100%); max-height: 90vh; overflow-y: auto; box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25); display: flex; flex-direction: column; gap: 1.25rem; position: relative; }
+    #adminModal h2 { margin: 0; font-size: 1.4rem; }
+    #closeAdmin { position: absolute; top: 1rem; right: 1rem; background: transparent; border: none; color: #555; font-size: 1.5rem; cursor: pointer; line-height: 1; }
+    #adminLoginSection, #adminPanel { display: flex; flex-direction: column; gap: 1rem; }
+    #adminLoginSection label, #adminPanel label { display: flex; flex-direction: column; gap: 0.4rem; font-size: 0.95rem; }
+    #adminLoginSection input, #adminPanel input { padding: 0.6rem; border-radius: 0.5rem; border: 1px solid #bbb; font-size: 1rem; }
+    #adminLoginBtn, #adminLogout, #createRoomForm button { padding: 0.65rem 1rem; font-size: 1rem; border-radius: 0.5rem; border: none; cursor: pointer; }
+    #adminLoginBtn { background: #2196f3; color: #fff; }
+    #adminLogout { align-self: flex-start; background: #eceff1; color: #37474f; }
+    #adminLogout:hover { background: #dfe4e8; }
+    #createRoomForm { display: grid; gap: 0.75rem; }
+    #createRoomForm h3 { margin: 0; font-size: 1.1rem; }
+    #createRoomForm button { background: #4caf50; color: #fff; justify-self: flex-start; }
+    #createRoomForm button:disabled { background: #a5d6a7; cursor: not-allowed; }
+    #adminRoomList { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.75rem; }
+    #adminRoomList li.empty { text-align: center; color: #666; font-style: italic; background: #f5f5f5; padding: 0.75rem; border-radius: 0.5rem; }
+    .admin-room-list-wrapper { display: flex; flex-direction: column; gap: 0.75rem; }
+    .admin-room-list-wrapper h3 { margin: 0; font-size: 1.1rem; }
+    .admin-room-item { display: flex; justify-content: space-between; gap: 1rem; background: #f1f8e9; border-radius: 0.75rem; padding: 0.75rem 1rem; align-items: flex-start; }
+    .admin-room-item .info { display: flex; flex-direction: column; gap: 0.3rem; }
+    .admin-room-item .name { font-weight: bold; font-size: 1.05rem; color: #1b5e20; }
+    .admin-room-item .password { font-size: 0.95rem; color: #33691e; }
+    .admin-room-item .meta { font-size: 0.8rem; color: #607d8b; }
+    .admin-room-item .actions { display: flex; gap: 0.5rem; }
+    .admin-room-item .actions .danger { background: #e53935; color: #fff; border: none; border-radius: 0.5rem; padding: 0.5rem 0.85rem; cursor: pointer; }
+    .admin-room-item .actions .danger:hover { background: #c62828; }
+    #adminError { color: #d32f2f; min-height: 1.2em; margin: 0; }
     @media (max-width: 768px) {
       #chatLayout { flex-direction: column; }
       #roomUsers { width: 100%; }
@@ -67,7 +101,10 @@
 </head>
 <body>
   <header>
-    <h1>PWA Chat App</h1>
+    <div class="header-inner">
+      <h1>PWA Chat App</h1>
+      <button id="openAdmin" type="button" class="admin-button">ルーム管理</button>
+    </div>
   </header>
   <main id="appContent" class="hidden">
     <section id="profile">
@@ -114,24 +151,56 @@
 
   <div id="joinModal" role="dialog" aria-modal="true">
     <div class="modal-content">
-    <    <h2>ルームに参加</h2>
-    <label>
+      <h2>ルームに参加</h2>
+      <label>
         ルーム名
-        <input id="roomNameInput" type="text" placeholder="ルーム名" autocomplete="off" />
-    </label>
-
-
-   
+        <input id="roomNameInput" type="text" placeholder="ルーム名" autocomplete="off" list="roomOptions" />
+        <datalist id="roomOptions"></datalist>
+      </label>
       <label>
         ユーザー名
         <input id="userNameInput" type="text" placeholder="ユーザー名" autocomplete="nickname" />
       </label>
       <label>
-        パスワード
+        ルームのパスワード
         <input id="passwordInput" type="password" placeholder="パスワード" autocomplete="current-password" />
       </label>
       <p id="joinError" aria-live="polite"></p>
       <button id="joinRoom">ルームに参加</button>
+    </div>
+  </div>
+
+  <div id="adminModal" class="hidden" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <button id="closeAdmin" type="button" aria-label="閉じる">×</button>
+      <h2>ルーム管理</h2>
+      <section id="adminLoginSection">
+        <label>
+          管理者パスワード
+          <input id="adminPasswordInput" type="password" placeholder="管理者パスワード" autocomplete="current-password" />
+        </label>
+        <button id="adminLoginBtn" type="button">ログイン</button>
+      </section>
+      <section id="adminPanel" class="hidden">
+        <form id="createRoomForm">
+          <h3>ルームを追加</h3>
+          <label>
+            ルーム名
+            <input id="newRoomName" type="text" placeholder="新しいルーム名" autocomplete="off" />
+          </label>
+          <label>
+            ルームのパスワード
+            <input id="newRoomPassword" type="password" placeholder="ルームのパスワード" autocomplete="new-password" />
+          </label>
+          <button type="submit">追加</button>
+        </form>
+        <div class="admin-room-list-wrapper">
+          <h3>既存のルーム</h3>
+          <ul id="adminRoomList"></ul>
+        </div>
+        <button id="adminLogout" type="button">ログアウト</button>
+      </section>
+      <p id="adminError" aria-live="polite"></p>
     </div>
   </div>
 

--- a/server.js
+++ b/server.js
@@ -11,24 +11,181 @@
 const express = require('express');
 const http = require('http');
 const { Server } = require('socket.io');
-const path = require('path');
+const crypto = require('crypto');
 
 
 const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
 
+app.use(express.json());
 // Serve static assets from the public directory
 app.use(express.static(__dirname));
+
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || '0623';
+// Public room directory (name -> meta)
+const roomDirectory = new Map();
 // Map of room names to array of socket IDs; used for group chat and voice calls
-const ROOM_PASSWORD = '0623';
-const rooms = new Map();
+const roomSockets = new Map();
+// Persist recent chat messages per room in memory
+const roomMessages = new Map();
+// Active admin session tokens
+const adminSessions = new Map();
 // Store basic profile info per socket to show user-friendly names
 const userProfiles = new Map();
 // Track current call participants per room so the UI can display them
 const callParticipants = new Map();
 // Track all room members so the client can display a roster
 const roomMembers = new Map();
+
+const MAX_MESSAGES_PER_ROOM = 500;
+const DEFAULT_ROOMS = [
+  { name: 'global', password: 'global' },
+];
+
+function sanitizeRoomName(name) {
+  return typeof name === 'string' ? name.trim() : '';
+}
+
+function ensureRoom(name) {
+  if (!roomDirectory.has(name)) {
+    return false;
+  }
+  if (!roomSockets.has(name)) {
+    roomSockets.set(name, new Set());
+  }
+  if (!roomMembers.has(name)) {
+    roomMembers.set(name, new Map());
+  }
+  if (!roomMessages.has(name)) {
+    roomMessages.set(name, []);
+  }
+  return true;
+}
+
+function getPublicRooms() {
+  return Array.from(roomDirectory.keys()).map((name) => ({ name }));
+}
+
+function getAdminRooms() {
+  return Array.from(roomDirectory.entries()).map(([name, info]) => ({
+    name,
+    password: info.password,
+    createdAt: info.createdAt,
+  }));
+}
+
+function broadcastRooms() {
+  io.emit('rooms-update', getPublicRooms());
+}
+
+function createRoom(name, password) {
+  const roomName = sanitizeRoomName(name);
+  if (!roomName) {
+    throw new Error('Room name is required.');
+  }
+  if (roomDirectory.has(roomName)) {
+    throw new Error('Room already exists.');
+  }
+  roomDirectory.set(roomName, {
+    password: typeof password === 'string' ? password : '',
+    createdAt: Date.now(),
+  });
+  ensureRoom(roomName);
+  broadcastRooms();
+  return roomName;
+}
+
+function deleteRoom(name) {
+  const roomName = sanitizeRoomName(name);
+  if (!roomDirectory.has(roomName)) {
+    throw new Error('Room not found.');
+  }
+
+  const sockets = roomSockets.get(roomName);
+  if (sockets) {
+    sockets.forEach((socketId) => {
+      const client = io.sockets.sockets.get(socketId);
+      if (client) {
+        client.leave(roomName);
+        client.emit('room-deleted', { room: roomName });
+      }
+      const profile = userProfiles.get(socketId);
+      if (profile) {
+        userProfiles.set(socketId, { ...profile, room: null });
+      }
+    });
+    roomSockets.delete(roomName);
+  }
+
+  roomDirectory.delete(roomName);
+  roomMessages.delete(roomName);
+  roomMembers.delete(roomName);
+  callParticipants.delete(roomName);
+  broadcastRooms();
+}
+
+DEFAULT_ROOMS.forEach(({ name, password }) => {
+  if (!roomDirectory.has(name)) {
+    try {
+      createRoom(name, password);
+    } catch (error) {
+      console.error('Failed to create default room', name, error);
+    }
+  }
+});
+
+function authenticateAdmin(req, res, next) {
+  const token = req.headers['x-admin-token'];
+  if (!token || !adminSessions.has(token)) {
+    return res.status(401).json({ ok: false, error: '認証が必要です。' });
+  }
+  return next();
+}
+
+app.get('/api/rooms', (req, res) => {
+  res.json({ rooms: getPublicRooms() });
+});
+
+app.post('/api/admin/login', (req, res) => {
+  const { password } = req.body || {};
+  if (password !== ADMIN_PASSWORD) {
+    return res.status(401).json({ ok: false, error: 'パスワードが違います。' });
+  }
+  const token = crypto.randomUUID();
+  adminSessions.set(token, { createdAt: Date.now() });
+  res.json({ ok: true, token, rooms: getAdminRooms() });
+});
+
+app.post('/api/admin/logout', authenticateAdmin, (req, res) => {
+  const token = req.headers['x-admin-token'];
+  adminSessions.delete(token);
+  res.json({ ok: true });
+});
+
+app.get('/api/admin/rooms', authenticateAdmin, (req, res) => {
+  res.json({ rooms: getAdminRooms() });
+});
+
+app.post('/api/admin/rooms', authenticateAdmin, (req, res) => {
+  const { name, password } = req.body || {};
+  try {
+    const created = createRoom(name, password);
+    res.status(201).json({ ok: true, room: created, rooms: getAdminRooms() });
+  } catch (error) {
+    res.status(400).json({ ok: false, error: error.message });
+  }
+});
+
+app.delete('/api/admin/rooms/:name', authenticateAdmin, (req, res) => {
+  const { name } = req.params;
+  try {
+    deleteRoom(name);
+    res.json({ ok: true, rooms: getAdminRooms() });
+  } catch (error) {
+    res.status(400).json({ ok: false, error: error.message });
+  }
+});
 
 function broadcastParticipants(room) {
   const participants = callParticipants.get(room);
@@ -47,14 +204,22 @@ function emitRoomUsers(room) {
 io.on('connection', (socket) => {
   console.log('a user connected:', socket.id);
 
-  // Join a room for group chat; default to 'global'
-  socket.on('join', (payload = 'global', maybeCallback) => {
+  // Join a room for group chat.
+  socket.on('join', (payload = {}, maybeCallback) => {
     const callback = typeof maybeCallback === 'function' ? maybeCallback : undefined;
-    const isObject = payload && typeof payload === 'object';
-    const room = isObject ? payload.room || 'global' : payload || 'global';
-    const password = isObject ? payload.password : undefined;
-    const rawName = isObject && typeof payload.user === 'string' ? payload.user.trim() : '';
-    if (password !== ROOM_PASSWORD) {
+    const roomName = sanitizeRoomName(payload.room);
+    const password = typeof payload.password === 'string' ? payload.password : undefined;
+    const rawName = typeof payload.user === 'string' ? payload.user.trim() : '';
+    if (!roomName) {
+      if (callback) callback({ ok: false, error: 'ルーム名を入力してください。' });
+      return;
+    }
+    const roomInfo = roomDirectory.get(roomName);
+    if (!roomInfo) {
+      if (callback) callback({ ok: false, error: '指定されたルームは存在しません。' });
+      return;
+    }
+    if (roomInfo.password !== password) {
       if (callback) callback({ ok: false, error: 'パスワードが違います。' });
       return;
     }
@@ -63,75 +228,95 @@ io.on('connection', (socket) => {
       return;
     }
 
-    const icon = isObject && Object.prototype.hasOwnProperty.call(payload, 'icon') && payload.icon
+    const icon = Object.prototype.hasOwnProperty.call(payload, 'icon') && payload.icon
       ? payload.icon
       : null;
 
-    let ids = rooms.get(room);
-    if (!ids) {
-      ids = new Set();
-      rooms.set(room, ids);
+    if (!ensureRoom(roomName)) {
+      if (callback) callback({ ok: false, error: 'ルームへの参加に失敗しました。' });
+      return;
     }
-    ids.add(socket.id);
-    socket.join(room);
 
-    const profile = { user: rawName, icon, room };
+    const ids = roomSockets.get(roomName);
+    ids.add(socket.id);
+    socket.join(roomName);
+
+    const profile = { user: rawName, icon, room: roomName };
     userProfiles.set(socket.id, profile);
 
-    let members = roomMembers.get(room);
-    if (!members) {
-      members = new Map();
-      roomMembers.set(room, members);
-    }
+    const members = roomMembers.get(roomName);
     members.set(socket.id, { id: socket.id, user: rawName, icon });
 
     // Notify others with a friendlier name when available
-    socket.to(room).emit('system', `${rawName} joined ${room}`);
+    socket.to(roomName).emit('system', `${rawName} joined ${roomName}`);
 
-    const participants = callParticipants.get(room);
+    const participants = callParticipants.get(roomName);
     socket.emit('call-participants', participants ? Array.from(participants.values()) : []);
-    emitRoomUsers(room);
+    emitRoomUsers(roomName);
 
-    if (callback) callback({ ok: true });
+    const history = roomMessages.get(roomName) || [];
+
+    if (callback) callback({ ok: true, room: roomName, messages: history });
   });
 
   // Chat message within a room
   socket.on('message', (msg = {}) => {
     const profile = userProfiles.get(socket.id);
-    if (!profile || !profile.room) {
+    const room = profile?.room;
+    if (!room) {
       return;
     }
-    const requestedRoom = typeof msg.room === 'string' && msg.room.trim() ? msg.room : profile.room;
-    const ids = rooms.get(requestedRoom);
-    if (!ids || !ids.has(socket.id)) {
+
+    const sockets = roomSockets.get(room);
+    if (!sockets || !sockets.has(socket.id)) {
       return;
     }
+
     const text = typeof msg.text === 'string' ? msg.text.trim() : '';
-    const location = msg.location;
+    const location = msg.location && typeof msg.location === 'object' ? msg.location : undefined;
     const incomingIcon = msg.icon;
-    const icon = profile.icon || incomingIcon || null;
+    let icon = profile.icon || null;
     if (incomingIcon && !profile.icon) {
+      icon = incomingIcon;
       const updatedProfile = { ...profile, icon: incomingIcon };
       userProfiles.set(socket.id, updatedProfile);
-      const members = roomMembers.get(requestedRoom);
+      const members = roomMembers.get(room);
       if (members && members.has(socket.id)) {
         const existing = members.get(socket.id);
         members.set(socket.id, { ...existing, icon: incomingIcon });
       }
     }
+
+    if (!text && !location) {
+      return;
+    }
+
     const payload = {
       user: profile.user,
       time: Date.now(),
     };
     if (text) payload.text = text;
-    if (icon) payload.icon = icon;
+    if (icon || incomingIcon) payload.icon = icon || incomingIcon;
     if (location) payload.location = location;
-    io.to(requestedRoom).emit('message', payload);
+
+    const history = roomMessages.get(room) || [];
+    history.push(payload);
+    if (history.length > MAX_MESSAGES_PER_ROOM) {
+      history.splice(0, history.length - MAX_MESSAGES_PER_ROOM);
+    }
+    roomMessages.set(room, history);
+
+    io.to(room).emit('message', payload);
   });
 
   // Signaling messages for WebRTC; forward to all peers in the room
-  socket.on('webrtc', ({ room = 'global', data }) => {
-    socket.to(room).emit('webrtc', { sender: socket.id, data });
+  socket.on('webrtc', ({ room, data } = {}) => {
+    const profile = userProfiles.get(socket.id);
+    const targetRoom = sanitizeRoomName(room) || profile?.room;
+    if (!targetRoom) {
+      return;
+    }
+    socket.to(targetRoom).emit('webrtc', { sender: socket.id, data });
   });
 
   socket.on('call-participation', (data = {}) => {
@@ -139,7 +324,10 @@ io.on('connection', (socket) => {
     if (!action) return;
     const profile = userProfiles.get(socket.id);
     if (!profile || !profile.room) return;
-    const room = data.room || profile.room;
+    const room = sanitizeRoomName(data.room) || profile.room;
+    if (!roomDirectory.has(room)) return;
+    const sockets = roomSockets.get(room);
+    if (!sockets || !sockets.has(socket.id)) return;
     const participants = callParticipants.get(room) || new Map();
     let changed = false;
 
@@ -183,14 +371,9 @@ io.on('connection', (socket) => {
     const profile = userProfiles.get(socket.id);
     const room = profile?.room;
     if (room) {
-      const ids = rooms.get(room);
+      const ids = roomSockets.get(room);
       if (ids) {
         ids.delete(socket.id);
-        if (ids.size === 0) {
-          rooms.delete(room);
-        } else {
-          rooms.set(room, ids);
-        }
       }
       const displayName = profile?.user || socket.id;
       socket.to(room).emit('system', `${displayName} left ${room}`);
@@ -207,11 +390,6 @@ io.on('connection', (socket) => {
       const members = roomMembers.get(room);
       if (members && members.has(socket.id)) {
         members.delete(socket.id);
-        if (members.size === 0) {
-          roomMembers.delete(room);
-        } else {
-          roomMembers.set(room, members);
-        }
         emitRoomUsers(room);
       }
     }
@@ -223,7 +401,12 @@ const PORT = process.env.PORT || 3000;
 
 const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
 setInterval(() => {
-  io.emit('clear-history');
+  roomMessages.forEach((messages, room) => {
+    if (messages.length > 0) {
+      roomMessages.set(room, []);
+      io.to(room).emit('clear-history', { room });
+    }
+  });
 }, TWELVE_HOURS_MS);
 
 server.listen(PORT, () => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,7 +5,7 @@
  * consider integrating IndexedDB or background sync.
  */
 
-const CACHE_NAME = 'pwa-chat-cache-v1';
+const CACHE_NAME = 'pwa-chat-cache-v2';
 const STATIC_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- add dynamic room support with per-room passwords and admin management endpoints/UI
- persist chat history locally and on the server, including history fetch on join and scheduled cleanup
- integrate Notification API and improved service worker cache along with UI refinements

## Testing
- node --check server.js
- node --check app.js

------
https://chatgpt.com/codex/tasks/task_e_68dc009ee1bc832e8c3ebf5d2511fc63