### PR TITLE
Rename app branding to Kのチャット

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PWA Chat App
+# Kのチャット
 
 This is a minimal progressive web app (PWA) that demonstrates how to build a simple chat application with group messaging and voice call capabilities using Socket.io and WebRTC.
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#2196f3" />
   <link rel="manifest" href="manifest.json">
-  <title>PWA Chat App</title>
+  <title>Kのチャット</title>
   <style>
     body { font-family: sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
     header { background: #2196f3; color: white; padding: 1rem; }
@@ -105,7 +105,7 @@
 <body>
   <header>
     <div class="header-inner">
-      <h1>PWA Chat App</h1>
+      <h1>Kのチャット</h1>
       <button id="openAdmin" type="button" class="admin-button">ルーム管理</button>
     </div>
   </header>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "PWA Chat App",
-  "short_name": "ChatApp",
+  "name": "Kのチャット",
+  "short_name": "Kのチャット",
   "description": "A simple PWA chat application with group chat and voice call",
   "start_url": "/",
   "scope": "/",


### PR DESCRIPTION
## Summary
- update the manifest branding to use the new name "Kのチャット"
- rename the visible app title in the HTML header to the new name
- refresh the README heading to match the updated branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc374f411c832eaf90b0cd60bd5dca